### PR TITLE
Handle Edge Case Imbalance

### DIFF
--- a/tests/trees/test_avl.py
+++ b/tests/trees/test_avl.py
@@ -68,7 +68,7 @@ class AVLTest(unittest.TestCase):
 
     def test_handle_left_left_imbalance_with_balanced_child_node(self):
         """
-        Test left left rotation on left heavy node whose child has a height > 1
+        Test left left imbalance on left heavy node whose child has a height > 1
         and whose balance = 0.
 
         Use 400 to avoid rotations when creating the tree.

--- a/tests/trees/test_avl.py
+++ b/tests/trees/test_avl.py
@@ -287,11 +287,11 @@ class AVLTest(unittest.TestCase):
 
     def test_delete_root_node(self):
         """
-                   40
-                  /  \
-                30    60
-                /    /  \
-              20    50   70
+                   40                        50
+                  /  \       after          /  \
+                30    60    rotation      30    70
+                /    /  \     ==>        /     /  \
+              20    50   70             20   60    80
                           \
                            80
         """
@@ -301,13 +301,14 @@ class AVLTest(unittest.TestCase):
         forty = self.avl.root
         sixty = forty.right
         fifty = sixty.left
+        seventy = sixty.right
         found = self.avl.find_node(forty.val)
         self.assertEqual(found, forty)
         self.avl.delete(forty)
         with self.assertRaises(Exception):
             found = self.avl.find_node(forty)
         self.assertEqual(self.avl.root, fifty)
-        self.assertEqual(fifty.right, sixty)
+        self.assertEqual(fifty.right, seventy)
 
     def test_avl_integrity_with_inorder_traversal(self):
         """

--- a/tests/trees/test_avl.py
+++ b/tests/trees/test_avl.py
@@ -66,6 +66,35 @@ class AVLTest(unittest.TestCase):
             self.avl.insert(node)
         self.avl.handle_lr_rotation.assert_called_with(None, self.avl.root)
 
+    def test_handle_left_left_imbalance_with_balanced_child_node(self):
+        """
+        Test left left rotation on left heavy node whose child has a height > 1
+        and whose balance = 0.
+
+        Use 400 to avoid rotations when creating the tree.
+        Delete 400 to create desired scenario.
+
+        Note: The desired tree state can be resolved by a left left rotation
+        or a left right rotation.
+
+                                (desired tree state)     (should resolve to this)
+                    100                 100                 70
+                   /   \               /                   /  \
+                 70     400    ==>   70          ==>      60   100
+                /  \                /  \                       /
+              60    80             60   80                    80
+        """
+        a = [100, 70, 400, 60, 80]
+        for node in a:
+            self.avl.insert(node)
+        four_hundred = self.avl.root.right
+        self.assertEqual(four_hundred.val, 400)
+        self.avl.delete(four_hundred)
+        self.assertEqual(self.avl.root.val, 70)
+        self.assertEqual(self.avl.root.left.val, 60)
+        self.assertEqual(self.avl.root.right.val, 100)
+        self.assertEqual(self.avl.root.right.left.val, 80)
+
     def test_right_right_rotation(self):
         """
              50

--- a/tests/trees/test_avl.py
+++ b/tests/trees/test_avl.py
@@ -95,6 +95,35 @@ class AVLTest(unittest.TestCase):
         self.assertEqual(self.avl.root.right.val, 100)
         self.assertEqual(self.avl.root.right.left.val, 80)
 
+    def test_handle_right_right_imbalance_with_balanced_child_node(self):
+        """
+        Test right right imbalance on right heavy node whose child has a
+        height > 1 and whose balance = 0.
+
+        Use 60 to avoid rotations when creating the tree.
+        Delete 60 to create desired scenario.
+
+        Note: The desired tree state can be resolved by a right right rotation
+        or a right left rotation.
+
+                                (desired tree state)     (should resolve to this)
+                    70                 70                   100
+                   /   \                 \                 /   \
+                 60     100    ==>       100      ==>    70    400
+                       /   \            /   \              \
+                      80   400        80    400            80
+        """
+        a = [70, 60, 100, 80, 400]
+        for node in a:
+            self.avl.insert(node)
+        sixry = self.avl.root.left
+        self.assertEqual(sixry.val, 60)
+        self.avl.delete(sixry)
+        self.assertEqual(self.avl.root.val, 100)
+        self.assertEqual(self.avl.root.left.val, 70)
+        self.assertEqual(self.avl.root.right.val, 400)
+        self.assertEqual(self.avl.root.left.right.val, 80)
+
     def test_right_right_rotation(self):
         """
              50

--- a/trees/bst/avl.py
+++ b/trees/bst/avl.py
@@ -117,6 +117,10 @@ class AVLTree:
                     parent.left = None
                 elif node == parent.right:
                     parent.right = None
+                successor_ancestors = self.search_ancestors(
+                    parent.right or parent.left or parent
+                )
+                self.rebalance_tree(successor_ancestors)
             del node
         elif node.left != None and node.right == None:
             if parent == None:
@@ -126,6 +130,8 @@ class AVLTree:
                     parent.left = node.left
                 elif node == parent.right:
                     parent.right = node.left
+            successor_ancestors = self.search_ancestors(node.left)
+            self.rebalance_tree(successor_ancestors)
             del node
         elif node.right != None:
             ios, ios_parent = self.inorder_successor(node)
@@ -139,6 +145,8 @@ class AVLTree:
                         parent.left = ios
                     elif node == parent.right:
                         parent.right = ios
+                successor_ancestors = self.search_ancestors(node.right)
+                self.rebalance_tree(successor_ancestors)
                 del node
             else:
                 ios_parent.left = ios.right
@@ -151,8 +159,11 @@ class AVLTree:
                         parent.left = ios
                     elif node == parent.right:
                         parent.right = ios
+                successor_ancestors = self.search_ancestors(
+                    ios_parent.right or ios_parent.left or ios_parent
+                )
+                self.rebalance_tree(successor_ancestors)
                 del node
-        self.rebalance_tree(ancestors)
 
     def inorder_successor(self, node):
         ios = node.right

--- a/trees/bst/avl.py
+++ b/trees/bst/avl.py
@@ -25,14 +25,14 @@ class AVLTree:
             if skew > 1:
                 # ll imbalance or lr imbalance
                 child_skew = self.get_balance(anc.left)
-                if child_skew == 1:
+                if child_skew == 1 or child_skew == 0:
                     self.handle_ll_rotation(parent, anc)
                 elif child_skew == -1:
                     self.handle_lr_rotation(parent, anc)
             elif skew < -1:
                 # rr imbalance or rl imbalance
                 child_skew = self.get_balance(anc.right)
-                if child_skew == -1:
+                if child_skew == -1 or child_skew == 0:
                     # rr imbalance
                     self.handle_rr_rotation(parent, anc)
                 elif child_skew == 1:


### PR DESCRIPTION
- Handle and add tests for edge case imbalance scenarios where child of unbalanced node has a height > 1 and it also has a balance of 0.
- For example:

> A left imbalanced node, 60
```
                       60
                      /
                    40
                  /    \
                 30    50
```

> A right imbalanced node, 60
```
                        60
                          \ 
                          80
                         /   \
                        70   90
```

- Left imbalanced nodes like the first one can be fixed by doing a `right rotation` or a `left-right rotation`.
- Right imbalanced nodes like the second one can be fixed by doing a `left rotation` or a `right-left rotation`.